### PR TITLE
Ajoute les sources de l'équipe Elastique

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Codes/Elastic/siroogle"]
+	path = Codes/Elastic/siroogle
+	url = https://github.com/hcstm/sirus-elasticsearch.git

--- a/Codes/Elastic/README.md
+++ b/Codes/Elastic/README.md
@@ -1,52 +1,11 @@
-<h1>Hackathon-2018 : "Les champs de Sirene"</h1>
+# Répertoire de l'équipe Elastique
 
-<p>Ce hackathon est organisé les 18 et 19 janvier 2017 à l'ENSAE (Malakoff). Pour être prêt à démarrer au matin du hackathon, venez à l'une des journées de préparation des 27 novembre ou 4 décembre à l'ENSAE pour des présentations techniques et la mise en place des outils.</p>
+Le repo du projet sir👓gleest disponibleici: https://github.com/hcstm/sirus-elasticsearch
 
+Le code source est enregistré comme sous-module `git` de ce repo.
 
-<h2>Pour nous suivre </h2>
+Pour récupérer la dernière version des codes sources :
 
-<p>Actualités sur le réseau <a href="https://www.yammer.com/bigdatadatascience/#/home">Yammer</a> dans le groupe "Hackathon : Les champs de Sirene"</p>
-
-
-<p>Contact pour plus d'informations : <a href="mailto:info-hackathon@insee.fr"> info-hackathon@insee.fr </a></p>
-
-<h2>Constitution des équipes</h2>
-
-<p>Afin de ne pas perdre trop de temps avec la constitution des équipes au matin du 18 janvier, les participants sont invités à se regrouper en amont en équipe (autour de 3-5 personnes environ).
-<p><b>Le google doc pour pré organiser les équipes : <a href="https://docs.google.com/spreadsheets/u/0/d/15WkJdsY9__25wBJmZGPB2dWpYczUwlhH-VhwkPl-Hbk/edit">ici</a>.</b>
-<p>N'hésitez pas à y préciser les idées que vous souhaiteriez creuser pendant le hackathon.
- 
- <p> La liste des participants est accessible <a href="https://docs.google.com/spreadsheets/d/1sLB1xERs_nPPi7uajd-SGMd4sjSK3TMfl3INOMcvWCc/edit#gid=805830236">ici</a>
- 
-<h2>Comment est organisé ce Github :</h2>
-
-<p>Sur ce repo Github on trouvera documentation, codes, actualités pour le hackathon organisé les 18 et 19 janvier 2017 à l'ENSAE.</p>
-
-<p>Le fichier "description générale" présente les principales informations relatives à l'événement.</p>
-
-<p>Le fichier "exemples" expose des cas d'identification difficile dans SIRENE à partir de données receuillies lors de l'Enquête emploi.</p>
-
-<p>Le fichier "journées de préparation" décrit le détail du programme des 27 novembre et 4 décembre 2017 à l'ENSAE.</p>
-
-<p> <b>Le dossier "données"</b> contient les présentations des données faites lors des journées de préparation :
-- sur les données du recensement
-- sur le répertoire Sirene
-- sur les données issues de Geoloc
-
-<p> <b>Le dossier "outils"</b> contient les présentations des outils faites lors des journées de préparation :
-- sur l'API Sirene : une doc, le lien vers la présentation et des tutos pour passer les requêtes depuis R ou Python
-- sur la gestion d'objets géographiques avec R : une présentation du package "sf"
-- sur le webscraping : des notebooks avec théorie, exemples et tutos
-
-<p> <b>Le dossier "sujet"</b> contient la présentation du sujet avec des exemples de difficultés d'identification faite pendant les journées de préparation.
-
-<p><b> Le dossier "Cookbooks"</b> contient des guides pour démarrer sur "comment qu'on code". Le menu général est <a href='https://github.com/SSP-Lab/Hackathon-2018/blob/master/Cookbooks/Menu%20g%C3%A9n%C3%A9ral.md'>là</a>
-
-<p> Et pour savoir combien nous sommes à <b>dîner ensemble le jeudi soir</b>, mettez votre nom <a href="https://doodle.com/poll/phc7298sxddqxznd#table">là</a>.
-
-<h2>Pour s'inscrire</h2>
-
-<p> inscriptions closes au 15 novembre
-
-<a href="https://www.weezevent.com/hackathon-les-champs-de-sirene-2" onclick="var w=window.open('https://www.weezevent.com/widget_billeterie.php?id_evenement=288620&lg_billetterie=1&code=52865&width_auto=1&color_primary=00AEEF', 'Billetterie_weezevent', 'width=650, height=600, top=100, left=100, toolbar=no, resizable=yes, scrollbars=yes, status=no'); w.focus(); return false;"><img src="https://www.weezevent.com/images/statique/bt_insc_blk_fr.png" alt="Inscription pour le hackathon" /></a>
+    git submodule init
+    git submodule update --remote
 

--- a/Codes/Elastic/README.md
+++ b/Codes/Elastic/README.md
@@ -1,6 +1,6 @@
 # Répertoire de l'équipe Elastique
 
-Le repo du projet sir👓gle est disponible ici: https://github.com/hcstm/sirus-elasticsearch
+Le repo du projet sir👓gle est disponible ici : https://github.com/hcstm/sirus-elasticsearch
 
 Le code source est enregistré comme sous-module `git` de ce repo.
 

--- a/Codes/Elastic/README.md
+++ b/Codes/Elastic/README.md
@@ -9,3 +9,4 @@ Pour récupérer la dernière version des codes sources :
     git submodule init
     git submodule update --remote
 
+Pour toute question : https://github.com/hcstm/sirus-elasticsearch/issues

--- a/Codes/Elastic/README.md
+++ b/Codes/Elastic/README.md
@@ -1,6 +1,6 @@
 # Répertoire de l'équipe Elastique
 
-Le repo du projet sir👓gleest disponibleici: https://github.com/hcstm/sirus-elasticsearch
+Le repo du projet sir👓gle est disponible ici: https://github.com/hcstm/sirus-elasticsearch
 
 Le code source est enregistré comme sous-module `git` de ce repo.
 


### PR DESCRIPTION
Bonjour,

Voici le PR de l'équipe Elastique.
Notre repo "officiel" est [hcstm/sirus-elasticsearch](https://github.com/hcstm/sirus-elasticsearch).

Ce PR : 
- enregistre le repo [hcstm/sirus-elasticsearch](https://github.com/hcstm/sirus-elasticsearch) comme sous-module `git` du repo `SSP-Lab/Hackathon-2018`
- modifie le README de l'équipe Elastique

Comme nous ferons peut-être encore un peu de ménage dans le code source, vous pourrez utilement faire un `git submodule update --remote` de temps en temps.  
Si nos sources changent significativement, je vous ferai un PR d'actualisation du sous-module.

Pour toute question sur notre projet, [c'est par ici !](https://github.com/hcstm/sirus-elasticsearch/issues)

Encore merci pour la super organisation !

Romain